### PR TITLE
Revert to pip3 install

### DIFF
--- a/deploy/azurelinux.Dockerfile
+++ b/deploy/azurelinux.Dockerfile
@@ -9,12 +9,17 @@ RUN tdnf -y install doxygen
 ## clang-format
 RUN tdnf -y install clang-tools-extra
 
-RUN tdnf -y install golang ca-certificates jq protobuf python3-pip python3-protobuf python3-grpcio
+RUN tdnf -y install golang ca-certificates jq protobuf python3-grpcio
 RUN go env -w GOFLAGS=-buildvcs=false
 RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3
 ENV PATH="/root/go/bin:${PATH}"
 
 WORKDIR /jbpf-protobuf
 COPY . /jbpf-protobuf
+
+RUN pip3 install -r /jbpf-protobuf/3p/nanopb/requirements.txt
+## TODO: We prefer the following rather than above
+## But the protobuf 3.20 is a hard requirement which is not available on ubuntu 22.04 through apt.
+## RUN apt install -y python3-protobuf python3-grpcio
 
 ENTRYPOINT [ "/jbpf-protobuf/deploy/entrypoint.sh" ]

--- a/deploy/azurelinux.Dockerfile
+++ b/deploy/azurelinux.Dockerfile
@@ -9,7 +9,7 @@ RUN tdnf -y install doxygen
 ## clang-format
 RUN tdnf -y install clang-tools-extra
 
-RUN tdnf -y install golang ca-certificates jq protobuf python3-grpcio
+RUN tdnf -y install golang ca-certificates jq python3-pip protobuf python3-grpcio
 RUN go env -w GOFLAGS=-buildvcs=false
 RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3
 ENV PATH="/root/go/bin:${PATH}"

--- a/deploy/azurelinux.Dockerfile
+++ b/deploy/azurelinux.Dockerfile
@@ -20,6 +20,6 @@ COPY . /jbpf-protobuf
 RUN pip3 install -r /jbpf-protobuf/3p/nanopb/requirements.txt
 ## TODO: We prefer the following rather than above
 ## But the protobuf 3.20 is a hard requirement which is not available on ubuntu 22.04 through apt.
-## RUN apt install -y python3-protobuf python3-grpcio
+## RUN tdnf install -y python3-protobuf python3-grpcio
 
 ENTRYPOINT [ "/jbpf-protobuf/deploy/entrypoint.sh" ]

--- a/deploy/ubuntu22_04.Dockerfile
+++ b/deploy/ubuntu22_04.Dockerfile
@@ -14,7 +14,7 @@ RUN apt install -y clang-format cppcheck
 RUN apt install -y clang gcc-multilib
 RUN apt install -y libyaml-cpp-dev
 
-RUN apt -y install protobuf-compiler python3-pip python3-protobuf python3-grpcio curl golang-1.23
+RUN apt -y install protobuf-compiler python3-pip curl golang-1.23
 ENV PATH="$PATH:/root/go/bin:/usr/local/go/bin:/usr/lib/go-1.23/bin"
 RUN go env -w GOFLAGS=-buildvcs=false
 RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3
@@ -23,5 +23,10 @@ ENV PATH="/root/go/bin:${PATH}"
 # Set the working directory and copy the project files
 WORKDIR /jbpf-protobuf
 COPY . /jbpf-protobuf
+
+RUN pip3 install -r /jbpf-protobuf/3p/nanopb/requirements.txt
+## TODO: We prefer the following rather than above
+## But the protobuf 3.20 is a hard requirement which is not available on ubuntu 22.04 through apt.
+## RUN apt install -y python3-protobuf python3-grpcio
 
 ENTRYPOINT [ "/jbpf-protobuf/deploy/entrypoint.sh" ]

--- a/deploy/ubuntu24_04.Dockerfile
+++ b/deploy/ubuntu24_04.Dockerfile
@@ -24,7 +24,7 @@ ENV PATH="/root/go/bin:${PATH}"
 WORKDIR /jbpf-protobuf
 COPY . /jbpf-protobuf
 
-RUN pip3 install -r /jbpf-protobuf/3p/nanopb/requirements.txt
+RUN pip3 install -r /jbpf-protobuf/3p/nanopb/requirements.txt --break-system-packages
 ## TODO: We prefer the following rather than above
 ## But the protobuf 3.20 is a hard requirement which is not available on ubuntu 22.04 through apt.
 ## RUN apt install -y python3-protobuf python3-grpcio

--- a/deploy/ubuntu24_04.Dockerfile
+++ b/deploy/ubuntu24_04.Dockerfile
@@ -14,7 +14,7 @@ RUN apt install -y clang-format cppcheck
 RUN apt install -y clang gcc-multilib
 RUN apt install -y libyaml-cpp-dev
 
-RUN apt -y install protobuf-compiler python3-pip python3-protobuf python3-grpcio curl golang-1.23
+RUN apt -y install protobuf-compiler python3-pip curl golang-1.23
 ENV PATH="$PATH:/root/go/bin:/usr/local/go/bin:/usr/lib/go-1.23/bin"
 RUN go env -w GOFLAGS=-buildvcs=false
 RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3
@@ -23,5 +23,10 @@ ENV PATH="/root/go/bin:${PATH}"
 # Set the working directory and copy the project files
 WORKDIR /jbpf-protobuf
 COPY . /jbpf-protobuf
+
+RUN pip3 install -r /jbpf-protobuf/3p/nanopb/requirements.txt
+## TODO: We prefer the following rather than above
+## But the protobuf 3.20 is a hard requirement which is not available on ubuntu 22.04 through apt.
+## RUN apt install -y python3-protobuf python3-grpcio
 
 ENTRYPOINT [ "/jbpf-protobuf/deploy/entrypoint.sh" ]


### PR DESCRIPTION
Re: https://github.com/microsoft/jbpf-protobuf/pull/16
To keep it consistent, we revert to previous pip3 install.